### PR TITLE
Fix undefined method `code` for Excon::Response

### DIFF
--- a/lib/microsoft_actionmailer/api.rb
+++ b/lib/microsoft_actionmailer/api.rb
@@ -62,7 +62,7 @@ module MicrosoftActionmailer
 
     def parse_error(response)
       body = if response.body.to_s.empty?
-               "{\"error\":{\"message\":\"Request returned #{response.code}\"}}"
+               "{\"error\":{\"message\":\"Request returned #{response.status}\"}}"
              else
                response.body
              end

--- a/lib/microsoft_actionmailer/version.rb
+++ b/lib/microsoft_actionmailer/version.rb
@@ -1,3 +1,3 @@
 module MicrosoftActionmailer
-  VERSION = "0.6.1"
+  VERSION = "0.6.2"
 end


### PR DESCRIPTION
`Excon::Response` provides [status](https://www.rubydoc.info/github/excon/excon/Excon%2FResponse:status) attribute instead of `code`.